### PR TITLE
build -> test -> publish with npm "prepublishOnly" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "pretest": "npm run build",
     "test": "run-s test:*",
     "test:standard": "standard",
-    "test:mocha": "NODE_ENV=test mocha 'test/*.js' -r @babel/polyfill -r @babel/register --exit"
+    "test:mocha": "NODE_ENV=test mocha 'test/*.js' -r @babel/polyfill -r @babel/register --exit",
+    "prepublishOnly": "npm test"
   },
   "keywords": [
     "async",


### PR DESCRIPTION
When call `npm publish`, always execute build and test before publishing to npmjs.com