### PR TITLE
Fixed a bug that prevented throwing an error more than once.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ module.exports = function asyncThrottle (func, { trailing } = {}) {
         queue = []
       }
       running = false
-    })().catch(reject)
+    })().catch(err => {
+      running = false
+      queue = []
+      reject(err)
+    })
   })
 }

--- a/test/index.js
+++ b/test/index.js
@@ -46,22 +46,24 @@ describe('async-throttle', function () {
 
     describe('on error', function () {
       it('throw error', async function () {
-        const throttled = asyncThrottle(async function () {
-          throw new Error('error')
+        const throttled = asyncThrottle(async function (msg) {
+          throw new Error(msg)
         })
         let err, err2
         try {
-          await throttled()
+          await throttled('error one')
         } catch (_err) {
           err = _err
         }
         try {
-          await throttled()
+          await throttled('error two')
         } catch (_err) {
           err2 = _err
         }
         assert.instanceOf(err, Error)
+        assert.equal(err.message, 'error one')
         assert.instanceOf(err2, Error)
+        assert.equal(err2.message, 'error two')
       })
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -49,13 +49,19 @@ describe('async-throttle', function () {
         const throttled = asyncThrottle(async function () {
           throw new Error('error')
         })
-        let err
+        let err, err2
         try {
           await throttled()
         } catch (_err) {
           err = _err
         }
+        try {
+          await throttled()
+        } catch (_err) {
+          err2 = _err
+        }
         assert.instanceOf(err, Error)
+        assert.instanceOf(err2, Error)
       })
     })
   })


### PR DESCRIPTION
```js
const throttled = asyncThrottle(fn)

try {
  await throttled()
} catch (err) {
  console.error(err)
}


try {
  await throttled()
} catch (err) {
  console.error(err) // cannot catch
}
```