### PR TITLE
bug fixed re-rerun of `trailing: true`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const last = arr => arr[arr.length - 1]
-
 module.exports = function asyncThrottle (func, { trailing } = {}) {
   if (typeof func !== 'function') throw new Error('argument is not function.')
   let running = false
@@ -10,13 +8,13 @@ module.exports = function asyncThrottle (func, { trailing } = {}) {
       running = true
       let result = await func(...args)
       resolve(result)
-      if (queue.length > 0) {
+      while (queue.length > 0) {
+        const length = queue.length
         if (trailing) {
-          const { args } = last(queue)
+          const { args } = queue[length - 1]
           result = await func(...args)
         }
-        queue.forEach(({ resolve }) => resolve(result))
-        queue = []
+        queue.splice(0, length).forEach(({ resolve }) => resolve(result))
       }
       running = false
     })().catch(err => {

--- a/test/index.js
+++ b/test/index.js
@@ -129,5 +129,33 @@ describe('async-throttle', function () {
       assert.equal(result3, 'done49')
       assert.equal(result4, 'done49')
     })
+
+    it('performs additional runs until queue is empty', async function () {
+      let result
+      const throttled = asyncThrottle(
+        async function (word) {
+          await delay(100)
+          result = word
+        },
+        { trailing: true }
+      )
+
+      throttled('s') // run
+      await delay(30)
+      throttled('se') // skip
+      await delay(30)
+      throttled('sea') // skip
+      await delay(30)
+      throttled('sear') // run after following assert.equal
+      await delay(30)
+      assert.equal(result, 's')
+      throttled('searc') // skip
+      await delay(30)
+      throttled('search') // run
+      await delay(100)
+      assert.equal(result, 'sear')
+      await delay(100)
+      assert.equal(result, 'search')
+    })
   })
 })


### PR DESCRIPTION
Fixed a bug that additional jobs were not executed if they were added to queue during the execution of an additional job by `trailing: true`.

- added test
  - 1st commit, it failed
- fixed the bug
  - test has been passed